### PR TITLE
fix(35): declare uint8 library

### DIFF
--- a/src/cpp/src/svd/exporters/svd_exporter_content.cpp
+++ b/src/cpp/src/svd/exporters/svd_exporter_content.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include "svd/exporters/svd_exporter_content.hpp"
 
 namespace svd::exporters {


### PR DESCRIPTION
**Description**
Fix C++ compilation error on Ubuntu 24.04.3 LTS, gcc 13.3.0

**Changes Proposed**
added include

**Checklist**

[x ] I have read and understood the contribution guidelines.
[x ] I have tested the changes locally and they function as expected.
[x ] I have included appropriate comments where necessary.
[x ] I have updated the documentation (if applicable).
[x ] I have checked for any potential conflicts with existing code.
[x ] I have run the code formatter and linter to ensure code consistency.
[x ] All tests have passed successfully.
[ ]  I have requested reviews from relevant team members.
[x ] I understand if my changes are breaking and indicated this accordingly in the PR title and description according to contribution guidelines.